### PR TITLE
Add NRF24L01 Pi5 example with wiring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # pi5-nrf24l01-tools
-Pi5的2.4GHz 无线收发使用(NRF24L01 )
+
+本仓库提供在 **Raspberry Pi 5** 上使用 NRF24L01 模块的示例代码。
+
+## 硬件连接
+
+下表给出了 NRF24L01 与 Raspberry Pi 5 之间的连接方式（BCM 编号）：
+
+| NRF24L01 引脚 | Raspberry Pi 5 |
+| ------------- | -------------- |
+| VCC           | 3.3V (PIN 1)   |
+| GND           | GND (PIN 6)    |
+| CE            | GPIO22 (PIN 15) |
+| CSN           | SPI0_CE0 (GPIO8, PIN 24) |
+| SCK           | SPI0_SCLK (GPIO11, PIN 23) |
+| MOSI          | SPI0_MOSI (GPIO10, PIN 19) |
+| MISO          | SPI0_MISO (GPIO9, PIN 21) |
+| IRQ           | GPIO24 (PIN 18，可选) |
+
+连接示意图可参考仓库中的 `device.jpg`。
+
+## 运行示例
+
+安装 Python 依赖：
+
+```bash
+sudo apt-get install python3-pip
+pip3 install spidev RPi.GPIO lib_nrf24
+```
+
+进入 `example` 目录，根据需要运行发送端或接收端脚本：
+
+```bash
+# 发送示例
+python3 example/tx.py
+
+# 接收示例
+python3 example/rx.py
+```
+
+脚本将在终端打印发送或接收到的消息，便于测试 NRF24L01 的通信。

--- a/example/rx.py
+++ b/example/rx.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Simple NRF24L01 receiver example for Raspberry Pi 5."""
+import time
+import spidev
+import RPi.GPIO as GPIO
+from lib_nrf24 import NRF24
+
+
+def main():
+    pipes = [b"1Node", b"2Node"]
+    GPIO.setmode(GPIO.BCM)
+
+    radio = NRF24(GPIO, spidev.SpiDev())
+    radio.begin(0, 22)  # ce=22, csn=0 -> CE0
+    radio.setPayloadSize(32)
+    radio.setChannel(0x76)
+    radio.setDataRate(NRF24.BR_1MBPS)
+    radio.setPALevel(NRF24.PA_MIN)
+
+    radio.openWritingPipe(list(pipes[1]))
+    radio.openReadingPipe(1, list(pipes[0]))
+    radio.startListening()
+
+    while True:
+        if radio.available():
+            received = []
+            radio.read(received, radio.getDynamicPayloadSize())
+            msg = ''.join(chr(x) for x in received if x != 0)
+            print("Received:", msg)
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        GPIO.cleanup()

--- a/example/tx.py
+++ b/example/tx.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Simple NRF24L01 transmitter example for Raspberry Pi 5."""
+import time
+import spidev
+import RPi.GPIO as GPIO
+from lib_nrf24 import NRF24
+
+
+def main():
+    # Pipes for communication (5 bytes each)
+    pipes = [b"1Node", b"2Node"]
+
+    GPIO.setmode(GPIO.BCM)
+
+    # CE on GPIO22, CSN on SPI0_CE0 (BCM8)
+    radio = NRF24(GPIO, spidev.SpiDev())
+    radio.begin(0, 22)  # ce=22, csn=0 -> CE0
+    radio.setPayloadSize(32)
+    radio.setChannel(0x76)
+    radio.setDataRate(NRF24.BR_1MBPS)
+    radio.setPALevel(NRF24.PA_MIN)
+
+    radio.openWritingPipe(list(pipes[0]))
+    radio.openReadingPipe(1, list(pipes[1]))
+    radio.stopListening()
+
+    while True:
+        message = list("Hello from Pi5")
+        # Pad message to 32 bytes
+        while len(message) < 32:
+            message.append(0)
+
+        radio.write(message)
+        print("Sent:", ''.join(chr(x) for x in message if x != 0))
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        GPIO.cleanup()


### PR DESCRIPTION
## Summary
- add example Python scripts for using an NRF24L01 transceiver with Raspberry Pi 5
- update README with wiring table, instructions and usage

## Testing
- `python3 -m py_compile example/tx.py example/rx.py`


------
https://chatgpt.com/codex/tasks/task_e_6877125adc088331983160d7df573144