### PR TITLE
Switch examples to lgpio

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ```bash
 sudo apt-get install python3-pip
-pip3 install spidev RPi.GPIO lib_nrf24
+pip3 install spidev lgpio lib_nrf24
 ```
 
 直接运行发送端或接收端脚本：

--- a/radio_helper.py
+++ b/radio_helper.py
@@ -1,5 +1,5 @@
 import spidev
-import RPi.GPIO as GPIO
+import lgpio as GPIO
 from lib_nrf24 import NRF24
 
 PIPES = [b"1Node", b"2Node"]

--- a/receive.py
+++ b/receive.py
@@ -2,7 +2,7 @@
 """Simple NRF24L01 receiver example for Raspberry Pi 5."""
 import time
 import spidev
-import RPi.GPIO as GPIO
+import lgpio as GPIO
 from lib_nrf24 import NRF24
 
 

--- a/send.py
+++ b/send.py
@@ -2,7 +2,7 @@
 """Simple NRF24L01 transmitter example for Raspberry Pi 5."""
 import time
 import spidev
-import RPi.GPIO as GPIO
+import lgpio as GPIO
 from lib_nrf24 import NRF24
 
 


### PR DESCRIPTION
## Summary
- use `lgpio` instead of the outdated `RPi.GPIO`
- update install instructions accordingly

## Testing
- `python3 -m py_compile send.py receive.py radio_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_6877584b58fc83318201285b14612eeb